### PR TITLE
FutureWarning

### DIFF
--- a/deltasigma/_stuffABCD.py
+++ b/deltasigma/_stuffABCD.py
@@ -72,10 +72,10 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         diagonal = diagonal_indices(ABCD[:order, :order])
         ABCD[diagonal] = np.ones((order,))
         subdiag = [i[even:order:2] for i in diagonal_indices(ABCD, -1)]
-        ABCD[subdiag] = c[0, even:order:2]
+        ABCD[tuple(subdiag)] = c[0, even:order:2]
         if order > odd:
             supdiag = [i[odd:order:2] for i in diagonal_indices(ABCD[:order, :order], +1)]
-            ABCD[supdiag] = -g.reshape((-1,))
+            ABCD[tuple(supdiag)] = -g.reshape((-1,))
         # row numbers of delaying integrators
         dly = np.arange(odd + 1, order, 2)
         ABCD[dly, :] = ABCD[dly, :] + np.dot(np.diag(c[0, dly - 1]), ABCD[dly - 1, :])
@@ -89,7 +89,7 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         ABCD[diagonal] = np.ones((order, ))
         # subdiag = diagonal[:order - 1:2] + 1
         subdiag = [i[:order - 1:2] for i in diagonal_indices(ABCD, -1)]
-        ABCD[subdiag] = c[0, 1:order:2]
+        ABCD[tuple(subdiag)] = c[0, 1:order:2]
         if even:
             # rows to have g*(following row) subtracted.
             multg = np.arange(0, order, 2)
@@ -100,7 +100,7 @@ def stuffABCD(a, g, b, c, form='CRFB'):
                 # supdiag = diagonal[2:order:2] - 1
                 supdiag = [i[1:order:2] for i in
                            diagonal_indices(ABCD[:order, :order], +1)]
-                ABCD[supdiag] = -g.reshape((-1,))
+                ABCD[tuple(supdiag)] = -g.reshape((-1,))
         # rows to have c*(preceding row) added.
         multc = np.arange(2, order, 2)
         ABCD[multc, :] = ABCD[multc, :] + np.dot(np.diag(c[0, multc]), ABCD[multc - 1, :])
@@ -119,7 +119,7 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         subdiag = diagonal_indices(ABCD, -1)
         ABCD[subdiag] = c.reshape((-1,))
         supdiag = [i[odd:order+odd:2] for i in diagonal_indices(ABCD[:order, :order], +1)]
-        ABCD[supdiag] = -g.reshape((-1,))
+        ABCD[tuple(supdiag)] = -g.reshape((-1,))
     elif form == 'CIFF':
         # B1 = (b_1 b_2... b_n), D=(b_(n+1) 0)
         ABCD[:, order] = b
@@ -134,7 +134,7 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         # supdiag = diagonal[odd + 1:order:2] - 1
         supdiag = [i[odd:order+odd:2] for i in  
                    diagonal_indices(ABCD[:order, :order], +1)]
-        ABCD[supdiag] = -g.reshape((-1,))
+        ABCD[tuple(supdiag)] = -g.reshape((-1,))
     elif form == 'CRFBD':
         # C=(0 0...c_n)
         ABCD[order, order - 1] = c[0, order - 1]
@@ -148,7 +148,7 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         dly = np.arange(odd, order, 2)
         subdiag = [np.atleast_1d(i)[dly] for i in
                    diagonal_indices(ABCD[:order, :order], -1)]
-        ABCD[subdiag] = c[0, dly]
+        ABCD[tuple(subdiag)] = c[0, dly]
         supdiag = [np.atleast_1d(i)[dly] for i in 
                    diagonal_indices(ABCD[:order, :order], +1)]
         supdiag = [np.atleast_1d(i[odd:]) for i in supdiag]
@@ -170,9 +170,9 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         # rows to have c*(preceding row) added.
         multc = np.arange(1, order, 2)
         if order > 2:
-            ABCD[[i[1::2] for i in subdiag]] = c[0, 2::2]
+            ABCD[[i[1::2] for i in tuple(subdiag)]] = c[0, 2::2]
         if even:
-            ABCD[[i[::2] for i in supdiag]] = -g.reshape((-1,))
+            ABCD[[i[::2] for i in tuple(supdiag)]] = -g.reshape((-1,))
         else:
             # subtract g*(following row) from the multc rows
             ABCD[multc, :] = ABCD[multc, :] - np.dot(np.diag(g[0, :]), ABCD[multc + 1, :])


### PR DESCRIPTION
Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  ABCD[[i[1::2] for i in subdiag]] = c[0, 2::2]