### PR TITLE
FutureWarning

### DIFF
--- a/deltasigma/_stuffABCD.py
+++ b/deltasigma/_stuffABCD.py
@@ -170,9 +170,9 @@ def stuffABCD(a, g, b, c, form='CRFB'):
         # rows to have c*(preceding row) added.
         multc = np.arange(1, order, 2)
         if order > 2:
-            ABCD[[i[1::2] for i in tuple(subdiag)]] = c[0, 2::2]
+            ABCD[tuple([i[1::2] for i in subdiag])] = c[0, 2::2]
         if even:
-            ABCD[[i[::2] for i in tuple(supdiag)]] = -g.reshape((-1,))
+            ABCD[tuple([i[::2] for i in supdiag])] = -g.reshape((-1,))
         else:
             # subtract g*(following row) from the multc rows
             ABCD[multc, :] = ABCD[multc, :] - np.dot(np.diag(g[0, :]), ABCD[multc + 1, :])


### PR DESCRIPTION
Using a non-tuple sequence for multidimensional indexing is deprecated; use `arr[tuple(seq)]` instead of `arr[seq]`. In the future this will be interpreted as an array index, `arr[np.array(seq)]`, which will result either in an error or a different result.
  ABCD[[i[::2] for i in tuple(supdiag)]] = -g.reshape((-1,))